### PR TITLE
프로필 등록 시 외부 프로젝트 소개 추가

### DIFF
--- a/src/main/java/com/hwarrk/common/dto/req/ProfileUpdateReq.java
+++ b/src/main/java/com/hwarrk/common/dto/req/ProfileUpdateReq.java
@@ -32,50 +32,23 @@ public record ProfileUpdateReq(
         List<CareerUpdateReq> careers,
         List<ProjectDescriptionUpdateReq> projectDescriptions
 ) {
-    public void updateMember(Member member, List<ProjectDescription> projectDescriptions) {
-        if (member.getRole() == Role.GUEST)
-            member.setRole(Role.USER);
 
-        member.setNickname(nickname);
-        member.setMemberStatus(memberStatus);
-        member.setEmail(email);
-        member.setIntroduction(introduction);
-        member.setIsVisible(isVisible);
-
-        member.addPositions(mapReqToPositions(member));
-        member.addPortfolios(mapReqToPortfolios(member));
-        member.addSkills(mapReqToSkills(member));
-        member.addDegrees(mapReqToDegrees(member));
-        member.addCareers(mapReqToCareers(member));
-
-        if (projectDescriptions != null) {
-            member.addProjectDescriptions(projectDescriptions);
-        }
-    }
-
-    public List<Portfolio> mapReqToPortfolios(Member member) {
-        return portfolios == null ?
-                Collections.emptyList() : portfolios.stream().map(portfolioLink -> new Portfolio(portfolioLink, member)).toList();
-    }
-
-    public List<Position> mapReqToPositions(Member member) {
-        return positions == null ?
-                Collections.emptyList() : positions.stream().map(position -> new Position(position, member)).toList();
-    }
-
-    public List<Skill> mapReqToSkills(Member member) {
-        return skills == null ?
-                Collections.emptyList() : skills.stream().map(skillType -> new Skill(skillType, member)).toList();
-    }
-
-    public List<Degree> mapReqToDegrees(Member member) {
-        return degrees == null ?
-                Collections.emptyList() : degrees.stream().map(degreeReq -> degreeReq.mapReqToEntity(member)).toList();
-    }
-
-    public List<Career> mapReqToCareers(Member member) {
-        return careers == null ?
-                Collections.emptyList() : careers.stream().map(careerReq -> careerReq.mapReqToEntity(member)).toList();
+    public Member mapReqToMember(String imageUrl, List<Position> positions, List<Portfolio> portfolios, List<Skill> skills,
+                                 List<Degree> degrees, List<Career> careers, List<ProjectDescription> projectDescriptions) {
+        return Member.builder()
+                .memberStatus(memberStatus)
+                .image(imageUrl)
+                .nickname(nickname)
+                .email(email)
+                .introduction(introduction)
+                .portfolios(portfolios)
+                .positions(positions)
+                .skills(skills)
+                .isVisible(isVisible)
+                .degrees(degrees)
+                .careers(careers)
+                .projectDescriptions(projectDescriptions)
+                .build();
     }
 
     public record DegreeUpdateReq(

--- a/src/main/java/com/hwarrk/common/dto/req/ProfileUpdateReq.java
+++ b/src/main/java/com/hwarrk/common/dto/req/ProfileUpdateReq.java
@@ -30,11 +30,12 @@ public record ProfileUpdateReq(
         boolean isVisible,
         List<DegreeUpdateReq> degrees,
         List<CareerUpdateReq> careers,
-        List<ProjectDescriptionUpdateReq> projectDescriptions
+        List<ProjectDescriptionUpdateReq> projectDescriptions,
+        List<ExternalProjectDescriptionUpdateReq> externalProjectDescriptions
 ) {
 
     public Member mapReqToMember(String imageUrl, List<Position> positions, List<Portfolio> portfolios, List<Skill> skills,
-                                 List<Degree> degrees, List<Career> careers, List<ProjectDescription> projectDescriptions) {
+                                 List<Degree> degrees, List<Career> careers, List<ProjectDescription> projectDescriptions, List<ExternalProjectDescription> externalProjectDescriptions) {
         return Member.builder()
                 .memberStatus(memberStatus)
                 .image(imageUrl)
@@ -48,6 +49,7 @@ public record ProfileUpdateReq(
                 .degrees(degrees)
                 .careers(careers)
                 .projectDescriptions(projectDescriptions)
+                .externalProjectDescriptions(externalProjectDescriptions)
                 .build();
     }
 
@@ -103,6 +105,31 @@ public record ProfileUpdateReq(
             return ProjectDescription.builder()
                     .project(project)
                     .member(member)
+                    .description(description)
+                    .build();
+        }
+    }
+
+    public record ExternalProjectDescriptionUpdateReq(
+            String projectName,
+            String domain,
+            LocalDate startDate,
+            LocalDate endDate,
+            ProjectStatus projectStatus,
+            PositionType positionType,
+            String subject,
+            String description
+    ) {
+
+        public ExternalProjectDescription mapReqToEntity(Member member) {
+            return ExternalProjectDescription.builder()
+                    .name(projectName)
+                    .domain(domain)
+                    .startDate(startDate)
+                    .endDate(endDate)
+                    .projectStatus(projectStatus)
+                    .positionType(positionType)
+                    .subject(subject)
                     .description(description)
                     .build();
         }

--- a/src/main/java/com/hwarrk/common/dto/req/ProfileUpdateReq.java
+++ b/src/main/java/com/hwarrk/common/dto/req/ProfileUpdateReq.java
@@ -12,7 +12,7 @@ import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 
-public record UpdateProfileReq(
+public record ProfileUpdateReq(
         @NotNull
         @Size(min = 2, max = 10)
         String nickname,
@@ -28,9 +28,9 @@ public record UpdateProfileReq(
         @NotNull
         List<SkillType> skills,
         boolean isVisible,
-        List<UpdateDegreeReq> degrees,
-        List<UpdateCareerReq> careers,
-        List<UpdateProjectDescriptionReq> projectDescriptions
+        List<DegreeUpdateReq> degrees,
+        List<CareerUpdateReq> careers,
+        List<ProjectDescriptionUpdateReq> projectDescriptions
 ) {
     public void updateMember(Member member, List<ProjectDescription> projectDescriptions) {
         if (member.getRole() == Role.GUEST)
@@ -78,7 +78,7 @@ public record UpdateProfileReq(
                 Collections.emptyList() : careers.stream().map(careerReq -> careerReq.mapReqToEntity(member)).toList();
     }
 
-    public record UpdateDegreeReq(
+    public record DegreeUpdateReq(
             String degreeType,
             String universityType,
             String school,
@@ -101,7 +101,7 @@ public record UpdateProfileReq(
         }
     }
 
-    public record UpdateCareerReq(
+    public record CareerUpdateReq(
             String company,
             String domain, // 직군
             String job, // 직무
@@ -122,7 +122,7 @@ public record UpdateProfileReq(
         }
     }
 
-    public record UpdateProjectDescriptionReq(
+    public record ProjectDescriptionUpdateReq(
             Long projectId,
             String description
     ) {

--- a/src/main/java/com/hwarrk/common/dto/res/ExternalProjectDescriptionRes.java
+++ b/src/main/java/com/hwarrk/common/dto/res/ExternalProjectDescriptionRes.java
@@ -1,0 +1,30 @@
+package com.hwarrk.common.dto.res;
+
+import com.hwarrk.common.constant.PositionType;
+import com.hwarrk.entity.ExternalProjectDescription;
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public record ExternalProjectDescriptionRes(
+        String name,
+        String domain,
+        LocalDate startDate,
+        LocalDate endDate,
+        PositionType positionType,
+        String subject,
+        String description
+) {
+    public static ExternalProjectDescriptionRes mapEntityToRes(ExternalProjectDescription externalProjectDescription) {
+        return ExternalProjectDescriptionRes.builder()
+                .name(externalProjectDescription.getName())
+                .domain(externalProjectDescription.getDomain())
+                .startDate(externalProjectDescription.getStartDate())
+                .endDate(externalProjectDescription.getEndDate())
+                .positionType(externalProjectDescription.getPositionType())
+                .subject(externalProjectDescription.getSubject())
+                .description(externalProjectDescription.getDescription())
+                .build();
+    }
+}

--- a/src/main/java/com/hwarrk/common/dto/res/MyProfileRes.java
+++ b/src/main/java/com/hwarrk/common/dto/res/MyProfileRes.java
@@ -20,7 +20,8 @@ public record MyProfileRes(
         boolean isVisible,
         List<DegreeRes> degrees,
         List<CareerRes> careers,
-        List<ProjectDescriptionRes> projectDescriptions
+        List<ProjectDescriptionRes> projectDescriptions,
+        List<ExternalProjectDescriptionRes> externalProjectDescriptions
 ) {
     public static MyProfileRes mapEntityToRes(Member member) {
         return MyProfileRes.builder()
@@ -35,6 +36,7 @@ public record MyProfileRes(
                 .degrees(member.getDegrees().stream().map(DegreeRes::mapEntityToRes).toList())
                 .careers(member.getCareers().stream().map(CareerRes::mapEntityToRes).toList())
                 .projectDescriptions(member.getProjectDescriptions().stream().map(ProjectDescriptionRes::mapEntityToRes).toList())
+                .externalProjectDescriptions(member.getExternalProjectDescriptions().stream().map(ExternalProjectDescriptionRes::mapEntityToRes).toList())
                 .build();
     }
 }

--- a/src/main/java/com/hwarrk/common/dto/res/ProfileRes.java
+++ b/src/main/java/com/hwarrk/common/dto/res/ProfileRes.java
@@ -21,7 +21,8 @@ public record ProfileRes(
         boolean isLiked,
         List<DegreeRes> degrees,
         List<CareerRes> careers,
-        List<ProjectDescriptionRes> projectDescriptions
+        List<ProjectDescriptionRes> projectDescriptions,
+        List<ExternalProjectDescriptionRes> externalProjectDescriptions
 ) {
 
     @QueryProjection
@@ -31,25 +32,14 @@ public record ProfileRes(
                 member.getMemberStatus(),
                 member.getEmail(),
                 member.getIntroduction(),
-                member.getPortfolios().stream()
-                        .map(Portfolio::getLink)
-                        .toList(),
-                member.getPositions().stream()
-                        .map(Position::getPositionType)
-                        .toList(),
-                member.getSkills().stream()
-                        .map(Skill::getSkillType)
-                        .toList(),
+                member.getPortfolios().stream().map(Portfolio::getLink).toList(),
+                member.getPositions().stream().map(Position::getPositionType).toList(),
+                member.getSkills().stream().map(Skill::getSkillType).toList(),
                 isLiked,
-                member.getDegrees().stream()
-                        .map(DegreeRes::mapEntityToRes)
-                        .toList(),
-                member.getCareers().stream()
-                        .map(CareerRes::mapEntityToRes)
-                        .toList(),
-                member.getProjectDescriptions().stream()
-                        .map(ProjectDescriptionRes::mapEntityToRes)
-                        .toList()
+                member.getDegrees().stream().map(DegreeRes::mapEntityToRes).toList(),
+                member.getCareers().stream().map(CareerRes::mapEntityToRes).toList(),
+                member.getProjectDescriptions().stream().map(ProjectDescriptionRes::mapEntityToRes).toList(),
+                member.getExternalProjectDescriptions().stream().map(ExternalProjectDescriptionRes::mapEntityToRes).toList()
         );
     }
 

--- a/src/main/java/com/hwarrk/controller/MemberController.java
+++ b/src/main/java/com/hwarrk/controller/MemberController.java
@@ -2,7 +2,7 @@ package com.hwarrk.controller;
 
 import com.hwarrk.common.apiPayload.CustomApiResponse;
 import com.hwarrk.common.dto.req.ProfileCond;
-import com.hwarrk.common.dto.req.UpdateProfileReq;
+import com.hwarrk.common.dto.req.ProfileUpdateReq;
 import com.hwarrk.common.dto.res.MyProfileRes;
 import com.hwarrk.common.dto.res.PageRes;
 import com.hwarrk.common.dto.res.ProfileRes;
@@ -50,9 +50,9 @@ public class MemberController {
     @Operation(summary = "프로필 작성")
     @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     public CustomApiResponse updateProfile(@AuthenticationPrincipal Long loginId,
-                                           @RequestPart UpdateProfileReq updateProfileReq,
+                                           @RequestPart ProfileUpdateReq profileUpdateReq,
                                            @RequestPart(value = "image", required = false) MultipartFile image) {
-        memberService.updateMember(loginId, updateProfileReq, image);
+        memberService.updateMember(loginId, profileUpdateReq, image);
         return CustomApiResponse.onSuccess();
     }
 

--- a/src/main/java/com/hwarrk/entity/ExternalProjectDescription.java
+++ b/src/main/java/com/hwarrk/entity/ExternalProjectDescription.java
@@ -1,0 +1,54 @@
+package com.hwarrk.entity;
+
+import com.hwarrk.common.constant.PositionType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "EXTERNAL_PROJECT_DESCRIPTION")
+public class ExternalProjectDescription {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "external_project_description_id")
+    private Long id;
+
+    private String name;
+
+    private String domain;
+
+    private LocalDate startDate;
+
+    private LocalDate endDate;
+
+    private PositionType positionType;
+
+    private String subject;
+
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    private ProjectStatus projectStatus;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Builder
+    public ExternalProjectDescription(String name, String domain, LocalDate startDate, LocalDate endDate, PositionType positionType, String subject, String description, ProjectStatus projectStatus, Member member) {
+        this.name = name;
+        this.domain = domain;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.positionType = positionType;
+        this.subject = subject;
+        this.description = description;
+        this.projectStatus = projectStatus;
+        this.member = member;
+    }
+}

--- a/src/main/java/com/hwarrk/entity/Member.java
+++ b/src/main/java/com/hwarrk/entity/Member.java
@@ -84,6 +84,9 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ProjectDescription> projectDescriptions = new ArrayList<>();
 
+    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ExternalProjectDescription> externalProjectDescriptions = new ArrayList<>();
+
     @OneToMany(mappedBy = "fromMember", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MemberLike> sentLikes = new ArrayList<>();
 
@@ -136,6 +139,11 @@ public class Member extends BaseEntity {
         this.projectDescriptions.addAll(projectDescriptions);
     }
 
+    public void addExternalProjectDescriptions(List<ExternalProjectDescription> externalProjectDescriptions) {
+        this.externalProjectDescriptions.clear();
+        this.externalProjectDescriptions.addAll(externalProjectDescriptions);
+    }
+
     public Member(String socialId, OauthProvider oauthProvider) {
         this.socialId = socialId;
         this.oauthProvider = oauthProvider;
@@ -152,8 +160,8 @@ public class Member extends BaseEntity {
 
     @Builder
     public Member(MemberStatus memberStatus, String image, String nickname, String birth, String email, String phone, String introduction,
-                  List<Portfolio> portfolios, List<Position> positions, List<Skill> skills, boolean isVisible,
-                  List<Degree> degrees, List<Career> careers, List<ProjectDescription> projectDescriptions) {
+                  List<Portfolio> portfolios, List<Position> positions, List<Skill> skills, boolean isVisible, List<Degree> degrees,
+                  List<Career> careers, List<ProjectDescription> projectDescriptions, List<ExternalProjectDescription> externalProjectDescriptions) {
         this.memberStatus = memberStatus;
         this.image = image;
         this.nickname = nickname;
@@ -168,6 +176,7 @@ public class Member extends BaseEntity {
         this.degrees = degrees;
         this.careers = careers;
         this.projectDescriptions = projectDescriptions;
+        this.externalProjectDescriptions = externalProjectDescriptions;
     }
 
     public void addProjectLike(ProjectLike projectLike) {
@@ -256,6 +265,7 @@ public class Member extends BaseEntity {
         this.addDegrees(updatedMember.getDegrees());
         this.addCareers(updatedMember.getCareers());
         this.addProjectDescriptions(updatedMember.getProjectDescriptions());
+        this.addExternalProjectDescriptions(updatedMember.getExternalProjectDescriptions());
     }
 
 }

--- a/src/main/java/com/hwarrk/entity/Member.java
+++ b/src/main/java/com/hwarrk/entity/Member.java
@@ -151,21 +151,23 @@ public class Member extends BaseEntity {
     }
 
     @Builder
-    public Member(MemberStatus memberStatus, String image, String nickname, String birth, String email, String phone,
-                  List<Portfolio> portfolios, List<Position> positions, List<Skill> skills,
-                  List<Degree> degrees,
-                  List<Career> careers) {
+    public Member(MemberStatus memberStatus, String image, String nickname, String birth, String email, String phone, String introduction,
+                  List<Portfolio> portfolios, List<Position> positions, List<Skill> skills, boolean isVisible,
+                  List<Degree> degrees, List<Career> careers, List<ProjectDescription> projectDescriptions) {
         this.memberStatus = memberStatus;
         this.image = image;
         this.nickname = nickname;
         this.birth = birth;
         this.email = email;
+        this.introduction = introduction;
         this.phone = phone;
         this.portfolios = portfolios;
         this.positions = positions;
         this.skills = skills;
+        this.isVisible = isVisible;
         this.degrees = degrees;
         this.careers = careers;
+        this.projectDescriptions = projectDescriptions;
     }
 
     public void addProjectLike(ProjectLike projectLike) {
@@ -236,4 +238,24 @@ public class Member extends BaseEntity {
     public void removeProjectMember(ProjectMember projectMember) {
         this.projectMembers.remove(projectMember);
     }
+
+    public void updateMember(Member updatedMember) {
+        if (this.role == Role.GUEST)
+            this.role = Role.USER;
+
+        this.memberStatus = updatedMember.getMemberStatus();
+        this.image = updatedMember.getImage();
+        this.nickname = updatedMember.getNickname();
+        this.email = updatedMember.getEmail();
+        this.introduction = updatedMember.getIntroduction();
+        this.isVisible = updatedMember.getIsVisible();
+
+        this.addPortfolios(updatedMember.getPortfolios());
+        this.addPositions(updatedMember.getPositions());
+        this.addSkills(updatedMember.getSkills());
+        this.addDegrees(updatedMember.getDegrees());
+        this.addCareers(updatedMember.getCareers());
+        this.addProjectDescriptions(updatedMember.getProjectDescriptions());
+    }
+
 }

--- a/src/main/java/com/hwarrk/entity/Member.java
+++ b/src/main/java/com/hwarrk/entity/Member.java
@@ -57,15 +57,19 @@ public class Member extends BaseEntity {
 
     private String introduction;
 
+    @BatchSize(size = 10)
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Portfolio> portfolios = new ArrayList<>();
 
+    @BatchSize(size = 10)
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Position> positions = new ArrayList<>();
 
+    @BatchSize(size = 10)
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Skill> skills = new ArrayList<>();
 
+    @BatchSize(size = 10)
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Degree> degrees = new ArrayList<>();
 
@@ -81,9 +85,11 @@ public class Member extends BaseEntity {
     @BatchSize(size = 10)
     private List<ProjectMember> projectMembers = new ArrayList<>();
 
+    @BatchSize(size = 10)
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ProjectDescription> projectDescriptions = new ArrayList<>();
 
+    @BatchSize(size = 10)
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ExternalProjectDescription> externalProjectDescriptions = new ArrayList<>();
 

--- a/src/main/java/com/hwarrk/repository/MemberRepositoryCustomImpl.java
+++ b/src/main/java/com/hwarrk/repository/MemberRepositoryCustomImpl.java
@@ -9,6 +9,7 @@ import com.hwarrk.common.dto.dto.QMemberWithLikeDto;
 import com.hwarrk.common.dto.req.ProfileCond;
 import com.hwarrk.common.dto.res.ProfileRes;
 import com.hwarrk.common.dto.res.QProfileRes;
+import com.hwarrk.entity.ExternalProjectDescription;
 import com.hwarrk.entity.Member;
 import com.hwarrk.common.dto.dto.ContentWithTotalDto;
 import com.querydsl.core.types.OrderSpecifier;
@@ -22,6 +23,7 @@ import java.util.List;
 
 import static com.hwarrk.entity.QCareer.career;
 import static com.hwarrk.entity.QDegree.degree;
+import static com.hwarrk.entity.QExternalProjectDescription.externalProjectDescription;
 import static com.hwarrk.entity.QMember.member;
 import static com.hwarrk.entity.QMemberLike.memberLike;
 import static com.hwarrk.entity.QPortfolio.portfolio;
@@ -45,6 +47,7 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
                 .leftJoin(member.degrees, degree)
                 .leftJoin(member.careers, career)
                 .leftJoin(member.projectDescriptions, projectDescription)
+                .leftJoin(member.externalProjectDescriptions, externalProjectDescription)
                 .where(eqMemberId(memberId))
                 .fetchOne();
 
@@ -65,6 +68,7 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
                 .leftJoin(member.degrees, degree)
                 .leftJoin(member.careers, career)
                 .leftJoin(member.projectDescriptions, projectDescription)
+                .leftJoin(member.externalProjectDescriptions, externalProjectDescription)
                 .leftJoin(memberLike)
                 .on(memberLike.fromMember.id.eq(fromMemberId).and(memberLike.toMember.id.eq(member.id)))
                 .where(eqMemberId(toMemberId))

--- a/src/main/java/com/hwarrk/service/MemberService.java
+++ b/src/main/java/com/hwarrk/service/MemberService.java
@@ -1,7 +1,7 @@
 package com.hwarrk.service;
 
 import com.hwarrk.common.dto.req.ProfileCond;
-import com.hwarrk.common.dto.req.UpdateProfileReq;
+import com.hwarrk.common.dto.req.ProfileUpdateReq;
 import com.hwarrk.common.dto.res.MyProfileRes;
 import com.hwarrk.common.dto.res.PageRes;
 import com.hwarrk.common.dto.res.ProfileRes;
@@ -12,7 +12,7 @@ import org.springframework.web.multipart.MultipartFile;
 public interface MemberService {
     void logout(HttpServletRequest request);
     void deleteMember(Long loginId);
-    void updateMember(Long loginId, UpdateProfileReq req, MultipartFile image);
+    void updateMember(Long loginId, ProfileUpdateReq req, MultipartFile image);
     MyProfileRes getMyProfile(Long memberId);
     ProfileRes getProfile(Long loginId, Long memberId);
     PageRes getMembers(Long memberId, ProfileCond cond, Pageable pageable);

--- a/src/main/java/com/hwarrk/service/MemberServiceImpl.java
+++ b/src/main/java/com/hwarrk/service/MemberServiceImpl.java
@@ -7,7 +7,7 @@ import com.hwarrk.common.constant.Role;
 import com.hwarrk.common.constant.TokenType;
 import com.hwarrk.common.dto.dto.ContentWithTotalDto;
 import com.hwarrk.common.dto.req.ProfileCond;
-import com.hwarrk.common.dto.req.UpdateProfileReq;
+import com.hwarrk.common.dto.req.ProfileUpdateReq;
 import com.hwarrk.common.dto.res.CareerInfoRes;
 import com.hwarrk.common.dto.res.MemberRes;
 import com.hwarrk.common.dto.res.MyProfileRes;
@@ -51,13 +51,13 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    public void updateMember(Long loginId, UpdateProfileReq updateProfileReq, MultipartFile image) {
+    public void updateMember(Long loginId, ProfileUpdateReq profileUpdateReq, MultipartFile image) {
         Member member = entityFacade.getMember(loginId);
 
         updateMemberImage(image, member);
 
-        List<ProjectDescription> projectDescriptions = getProjectDescriptions(updateProfileReq, member);
-        updateProfileReq.updateMember(member, projectDescriptions);
+        List<ProjectDescription> projectDescriptions = getProjectDescriptions(profileUpdateReq, member);
+        profileUpdateReq.updateMember(member, projectDescriptions);
     }
 
     @Override
@@ -101,11 +101,11 @@ public class MemberServiceImpl implements MemberService {
         return PageRes.mapResToPageRes(memberResPage);
     }
 
-    private List<ProjectDescription> getProjectDescriptions(UpdateProfileReq updateProfileReq, Member member) {
-        if (updateProfileReq.projectDescriptions() == null)
+    private List<ProjectDescription> getProjectDescriptions(ProfileUpdateReq profileUpdateReq, Member member) {
+        if (profileUpdateReq.projectDescriptions() == null)
             return null;
 
-        return updateProfileReq.projectDescriptions().stream()
+        return profileUpdateReq.projectDescriptions().stream()
                 .map(updateProjectDescriptionReq -> {
                     Project project = entityFacade.getProject(updateProjectDescriptionReq.projectId());
                     return updateProjectDescriptionReq.mapReqToEntity(member, project);

--- a/src/main/java/com/hwarrk/service/MemberServiceImpl.java
+++ b/src/main/java/com/hwarrk/service/MemberServiceImpl.java
@@ -58,7 +58,7 @@ public class MemberServiceImpl implements MemberService {
         String imageUrl = updateMemberImage(image, member);
 
         List<Position> positions = profileUpdateReq.positions() == null ?
-                Collections.emptyList() : profileUpdateReq.positions().stream().map(position -> new Position(position, member)).toList();
+                Collections.emptyList() : profileUpdateReq.positions().stream().map(positionType -> new Position(positionType, member)).toList();
 
         List<Portfolio> portfolios = profileUpdateReq.portfolios() == null ?
                 Collections.emptyList() : profileUpdateReq.portfolios().stream().map(portfolioLink -> new Portfolio(portfolioLink, member)).toList();
@@ -74,13 +74,19 @@ public class MemberServiceImpl implements MemberService {
 
         List<ProjectDescription> projectDescriptions = profileUpdateReq.projectDescriptions() == null ?
                 Collections.emptyList() : profileUpdateReq.projectDescriptions().stream()
-                .map(updateProjectDescriptionReq -> {
-                    Project project = entityFacade.getProject(updateProjectDescriptionReq.projectId());
-                    return updateProjectDescriptionReq.mapReqToEntity(member, project);
+                .map(projectDescriptionUpdateReq -> {
+                    Project project = entityFacade.getProject(projectDescriptionUpdateReq.projectId());
+                    return projectDescriptionUpdateReq.mapReqToEntity(member, project);
                 })
                 .toList();
 
-        member.updateMember(profileUpdateReq.mapReqToMember(imageUrl, positions, portfolios, skills, degrees, careers, projectDescriptions));
+        List<ExternalProjectDescription> externalProjectDescriptions = profileUpdateReq.externalProjectDescriptions() == null ?
+                Collections.emptyList() : profileUpdateReq.externalProjectDescriptions().stream()
+                .map(externalProjectDescriptionUpdateReq -> externalProjectDescriptionUpdateReq.mapReqToEntity(member))
+                .toList();
+
+        Member updatedMember = profileUpdateReq.mapReqToMember(imageUrl, positions, portfolios, skills, degrees, careers, projectDescriptions, externalProjectDescriptions);
+        member.updateMember(updatedMember);
     }
 
     @Override

--- a/src/test/java/com/hwarrk/service/MemberServiceTest.java
+++ b/src/test/java/com/hwarrk/service/MemberServiceTest.java
@@ -1,8 +1,8 @@
 package com.hwarrk.service;
 
-import static com.hwarrk.common.dto.req.UpdateProfileReq.UpdateCareerReq;
-import static com.hwarrk.common.dto.req.UpdateProfileReq.UpdateDegreeReq;
-import static com.hwarrk.common.dto.req.UpdateProfileReq.UpdateProjectDescriptionReq;
+import static com.hwarrk.common.dto.req.ProfileUpdateReq.CareerUpdateReq;
+import static com.hwarrk.common.dto.req.ProfileUpdateReq.DegreeUpdateReq;
+import static com.hwarrk.common.dto.req.ProfileUpdateReq.ProjectDescriptionUpdateReq;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -15,7 +15,7 @@ import com.hwarrk.common.constant.PositionType;
 import com.hwarrk.common.constant.Role;
 import com.hwarrk.common.constant.SkillType;
 import com.hwarrk.common.dto.req.ProfileCond;
-import com.hwarrk.common.dto.req.UpdateProfileReq;
+import com.hwarrk.common.dto.req.ProfileUpdateReq;
 import com.hwarrk.common.dto.res.MemberRes;
 import com.hwarrk.common.dto.res.MyProfileRes;
 import com.hwarrk.common.dto.res.PageRes;
@@ -70,7 +70,7 @@ class MemberServiceTest {
     Project project_01;
     Project project_02;
 
-    List<UpdateProjectDescriptionReq> projectDescriptions;
+    List<ProjectDescriptionUpdateReq> projectDescriptions;
 
     String nickname = "LSH";
     MemberStatus memberStatus = MemberStatus.사프_찾는_중;
@@ -80,8 +80,8 @@ class MemberServiceTest {
     List<PositionType> positions = List.of(PositionType.PM, PositionType.BACKEND);
     List<SkillType> skills = List.of(SkillType.JAVA, SkillType.SPRING);
     boolean isVisible = true;
-    List<UpdateDegreeReq> degrees = List.of(
-            new UpdateDegreeReq(
+    List<DegreeUpdateReq> degrees = List.of(
+            new DegreeUpdateReq(
                     "University",
                     "University A",
                     "School A",
@@ -90,7 +90,7 @@ class MemberServiceTest {
                     "2010-09-01",
                     "2014-06-01"
             ),
-            new UpdateDegreeReq(
+            new DegreeUpdateReq(
                     "University",
                     "University B",
                     "School B",
@@ -100,8 +100,8 @@ class MemberServiceTest {
                     "2017-06-01"
             )
     );
-    List<UpdateCareerReq> careers = List.of(
-            new UpdateCareerReq(
+    List<CareerUpdateReq> careers = List.of(
+            new CareerUpdateReq(
                     "Company A",
                     "Engineering",
                     "Software Engineer",
@@ -109,7 +109,7 @@ class MemberServiceTest {
                     LocalDate.of(2020, 12, 31),
                     "Developed software"
             ),
-            new UpdateCareerReq(
+            new CareerUpdateReq(
                     "Company B",
                     "Product Design",
                     "UX Designer",
@@ -125,8 +125,8 @@ class MemberServiceTest {
         project_01 = projectRepository.save(new Project("Project name", "Project introduction", member_01));
         project_02 = projectRepository.save(new Project("Project name", "Project introduction", member_01));
         projectDescriptions = List.of(
-                new UpdateProjectDescriptionReq(project_01.getId(), "Project description_01"),
-                new UpdateProjectDescriptionReq(project_02.getId(), "Project description_02")
+                new ProjectDescriptionUpdateReq(project_01.getId(), "Project description_01"),
+                new ProjectDescriptionUpdateReq(project_02.getId(), "Project description_02")
         );
     }
 
@@ -197,7 +197,7 @@ class MemberServiceTest {
     @Test
     void 프로필_작성() {
         //given
-        UpdateProfileReq req = new UpdateProfileReq(nickname, memberStatus, email, introduction, portfolios, positions, skills, isVisible, degrees, careers, projectDescriptions);
+        ProfileUpdateReq req = new ProfileUpdateReq(nickname, memberStatus, email, introduction, portfolios, positions, skills, isVisible, degrees, careers, projectDescriptions);
 
         //when
         memberService.updateMember(member_01.getId(), req, null);
@@ -220,7 +220,7 @@ class MemberServiceTest {
     @Test
     void 프로필_수정() {
         //given
-        UpdateProfileReq req = new UpdateProfileReq(nickname, memberStatus, email, introduction, null, positions, null, isVisible, null, null, projectDescriptions);
+        ProfileUpdateReq req = new ProfileUpdateReq(nickname, memberStatus, email, introduction, null, positions, null, isVisible, null, null, projectDescriptions);
         memberService.updateMember(member_01.getId(), req, null);
 
         String updateNickname = "홍길동";
@@ -229,11 +229,11 @@ class MemberServiceTest {
         String updateIntroduction = "홍길동";
         List<PositionType> updatePositions = List.of(PositionType.FRONTEND, PositionType.GRAPHIC_DESIGNER, PositionType.PO);
         boolean updateIsVisible = true;
-        List<UpdateProjectDescriptionReq> updateProjectDescriptions = List.of(
-                new UpdateProjectDescriptionReq(project_01.getId(), "Update Project description_01")
+        List<ProjectDescriptionUpdateReq> updateProjectDescriptions = List.of(
+                new ProjectDescriptionUpdateReq(project_01.getId(), "Update Project description_01")
         );
 
-        UpdateProfileReq updateReq = new UpdateProfileReq(
+        ProfileUpdateReq updateReq = new ProfileUpdateReq(
                 updateNickname, updateMemberStatus, updateEmail, updateIntroduction, null, updatePositions, null, updateIsVisible, null, null, updateProjectDescriptions);
 
         //when
@@ -258,7 +258,7 @@ class MemberServiceTest {
     @Test
     void 나의_프로필_조회() {
         //given
-        UpdateProfileReq req = new UpdateProfileReq(nickname, memberStatus, email, introduction, portfolios, positions, skills, isVisible, degrees, careers, projectDescriptions);
+        ProfileUpdateReq req = new ProfileUpdateReq(nickname, memberStatus, email, introduction, portfolios, positions, skills, isVisible, degrees, careers, projectDescriptions);
         memberService.updateMember(member_01.getId(), req, null);
 
         //when
@@ -289,7 +289,7 @@ class MemberServiceTest {
         //given
         Member member_02 = memberRepository.save(new Member("test_02", OauthProvider.KAKAO));
         member_02.setRole(Role.USER);
-        UpdateProfileReq req = new UpdateProfileReq(nickname, memberStatus, email, introduction, portfolios, positions, skills, isVisible, degrees, careers, projectDescriptions);
+        ProfileUpdateReq req = new ProfileUpdateReq(nickname, memberStatus, email, introduction, portfolios, positions, skills, isVisible, degrees, careers, projectDescriptions);
         memberService.updateMember(member_01.getId(), req, null);
 
         memberLikeRepository.save(new MemberLike(member_02, member_01));
@@ -352,7 +352,7 @@ class MemberServiceTest {
         //given
         Member member_02 = memberRepository.save(new Member("test_02", OauthProvider.KAKAO));
         Member member_03 = memberRepository.save(new Member("test_03", OauthProvider.KAKAO));
-        UpdateProfileReq req = new UpdateProfileReq(nickname, memberStatus, email, introduction, portfolios, positions, skills, isVisible, degrees, careers, projectDescriptions);
+        ProfileUpdateReq req = new ProfileUpdateReq(nickname, memberStatus, email, introduction, portfolios, positions, skills, isVisible, degrees, careers, projectDescriptions);
         memberService.updateMember(member_02.getId(), req, null);
         memberService.updateMember(member_03.getId(), req, null);
 


### PR DESCRIPTION
## ⭐ Summary

> 프로필 등록 시 외부 프로젝트 소개 추가

- close #[ISSUE_NUMBER]


<br>

## 📌 Tasks

1. 프로필 등록/수정 api에서 데이터 처리를 서비스 계층에서 진행하도록 수정
2. UpdateProfileReq와 inner record 이름을 ProfileUpdateReq 형식으로 rename
3. 프로필 등록 시 외부 프로젝트 소개 추가

<br>

