### PR TITLE
채팅관련 로직 리팩토링

### DIFF
--- a/src/main/java/com/hwarrk/common/apiPayload/code/statusEnums/ErrorStatus.java
+++ b/src/main/java/com/hwarrk/common/apiPayload/code/statusEnums/ErrorStatus.java
@@ -93,8 +93,9 @@ public enum ErrorStatus implements BaseCode {
     NOT_CHAT_ROOM_MEMBER(HttpStatus.FORBIDDEN, "CHAT_ROOM_MEMBER4031", "채팅방에 참여 중인 사용자가 아닙니다."),
 
     // Stomp header
-    MISSING_CHAT_ROOM_ID(HttpStatus.BAD_REQUEST, "CHATROOM4002", "Stomp header에 chat-room-id 존재하지 않습니다"),
-    MISSING_MEMBER_ID_IN_SESSION(HttpStatus.BAD_REQUEST, "CHATROOM4002", "Stomp header session에 memberId가 존재하지 않습니다");
+    MISSING_CHAT_ROOM_ID_IN_HEADER(HttpStatus.BAD_REQUEST, "STOMP4001", "Stomp header에 chat-room-id 존재하지 않습니다"),
+    MISSING_MEMBER_ID_IN_SESSION(HttpStatus.BAD_REQUEST, "STOMP4002", "Stomp header session에 memberId가 존재하지 않습니다"), 
+    MISSING_CHAT_ROOM_ID_IN_SESSION(HttpStatus.BAD_REQUEST, "STOMP4003", "Stomp header session에 chat-room-id 존재하지 않습니다" );
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/hwarrk/common/apiPayload/code/statusEnums/ErrorStatus.java
+++ b/src/main/java/com/hwarrk/common/apiPayload/code/statusEnums/ErrorStatus.java
@@ -94,7 +94,7 @@ public enum ErrorStatus implements BaseCode {
 
     // Stomp header
     MISSING_CHAT_ROOM_ID_IN_HEADER(HttpStatus.BAD_REQUEST, "STOMP4001", "Stomp header에 chat-room-id 존재하지 않습니다"),
-    MISSING_MEMBER_ID_IN_SESSION(HttpStatus.BAD_REQUEST, "STOMP4002", "Stomp header session에 memberId가 존재하지 않습니다"), 
+    MISSING_MEMBER_ID_IN_SESSION(HttpStatus.BAD_REQUEST, "STOMP4002", "Stomp header session에 memberId가 존재하지 않습니다"),
     MISSING_CHAT_ROOM_ID_IN_SESSION(HttpStatus.BAD_REQUEST, "STOMP4003", "Stomp header session에 chat-room-id 존재하지 않습니다" );
 
 

--- a/src/main/java/com/hwarrk/common/config/RedisConfig.java
+++ b/src/main/java/com/hwarrk/common/config/RedisConfig.java
@@ -27,6 +27,7 @@ public class RedisConfig {
         return new LettuceConnectionFactory(redisHost, redisPort);
     }
 
+    // jwt -> memberId
     @Bean
     public RedisTemplate<String, Long> StringLongRedisTemplate() {
         RedisTemplate<String, Long> redisTemplate = new RedisTemplate<>();
@@ -36,21 +37,13 @@ public class RedisConfig {
         return redisTemplate;
     }
 
+    // chatRoomId -> SET {memberId_01, memberId_02, ...}
     @Bean
     public RedisTemplate<Long, Long> LongLongRedisTemplate() {
         RedisTemplate<Long, Long> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
         redisTemplate.setKeySerializer(new Jackson2JsonRedisSerializer<>(Long.class));
         redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(Long.class));
-        return redisTemplate;
-    }
-
-    @Bean
-    public RedisTemplate<String, Integer> StringIntegerRedisTemplate() {
-        RedisTemplate<String, Integer> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(redisConnectionFactory());
-        redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(Integer.class));
         return redisTemplate;
     }
 

--- a/src/main/java/com/hwarrk/common/config/WebSocketConfig.java
+++ b/src/main/java/com/hwarrk/common/config/WebSocketConfig.java
@@ -1,8 +1,10 @@
 package com.hwarrk.common.config;
 
+import com.hwarrk.jwt.JwtAuthenticationInterceptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
@@ -14,6 +16,7 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
+    private final JwtAuthenticationInterceptor jwtAuthenticationInterceptor;
 
     @Value("${rabbitmq.host}")
     private String host;
@@ -50,8 +53,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     }
 
-//    @Override
-//    public void configureClientInboundChannel(ChannelRegistration registration) {
-//        registration.interceptors(inboundChannelInterceptor);
-//    }
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(jwtAuthenticationInterceptor);
+    }
 }

--- a/src/main/java/com/hwarrk/common/dto/req/ChatMessageReq.java
+++ b/src/main/java/com/hwarrk/common/dto/req/ChatMessageReq.java
@@ -3,15 +3,13 @@ package com.hwarrk.common.dto.req;
 import com.hwarrk.entity.ChatMessage;
 
 public record ChatMessageReq(
-        Long chatRoomId,
         String message
 ) {
-    public ChatMessage createChatMessage(Long chatRoomId, Long memberId, int unreadCnt) {
+    public ChatMessage createChatMessage(Long chatRoomId, Long memberId) {
         return ChatMessage.builder()
                 .chatRoomId(chatRoomId)
                 .memberId(memberId)
                 .message(message)
-                .unreadCnt(unreadCnt)
                 .build();
     }
 }

--- a/src/main/java/com/hwarrk/common/dto/req/OauthLoginReq.java
+++ b/src/main/java/com/hwarrk/common/dto/req/OauthLoginReq.java
@@ -13,7 +13,7 @@ import lombok.Setter;
 @NoArgsConstructor
 public class OauthLoginReq {
     @NotNull
-    @Schema(name = "소셜 로그인 제공자", examples = {"KAKAO", "GOOGLE", "APPLE"})
+    @Schema(description = "소셜 로그인 제공자", examples = {"KAKAO", "GOOGLE", "APPLE"})
     private OauthProvider oauthProvider;
 
     @NotBlank

--- a/src/main/java/com/hwarrk/common/dto/res/ChatMessageRes.java
+++ b/src/main/java/com/hwarrk/common/dto/res/ChatMessageRes.java
@@ -8,26 +8,21 @@ import java.time.LocalDateTime;
 
 @Getter
 public class ChatMessageRes extends MessageRes {
+    static private final MessageType messageType = MessageType.CHAT_MESSAGE;
     private Long memberId;
     private String message;
     private LocalDateTime createdAt;
     private int unreadCnt;
 
-    private ChatMessageRes(MessageType messageType, Long memberId, String message, LocalDateTime createdAt, int unreadCnt) {
+    private ChatMessageRes(Long memberId, String message, LocalDateTime createdAt, int unreadCnt) {
         super(messageType);
         this.memberId = memberId;
         this.message = message;
-        this.unreadCnt = unreadCnt;
         this.createdAt = createdAt;
+        this.unreadCnt = unreadCnt;
     }
 
-    public static ChatMessageRes createRes(MessageType messageType, ChatMessage chatMessage, int unreadCnt) {
-        return new ChatMessageRes(
-                messageType,
-                chatMessage.getMemberId(),
-                chatMessage.getMessage(),
-                chatMessage.getCreatedAt(),
-                unreadCnt
-        );
+    public static MessageRes createRes(ChatMessage chatMessage, int unreadCnt) {
+        return new ChatMessageRes(chatMessage.getMemberId(), chatMessage.getMessage(), chatMessage.getCreatedAt(), unreadCnt);
     }
 }

--- a/src/main/java/com/hwarrk/common/dto/res/ChatMessageRes.java
+++ b/src/main/java/com/hwarrk/common/dto/res/ChatMessageRes.java
@@ -10,10 +10,10 @@ import java.time.LocalDateTime;
 public class ChatMessageRes extends MessageRes {
     private Long memberId;
     private String message;
-    private int unreadCnt;
     private LocalDateTime createdAt;
+    private int unreadCnt;
 
-    private ChatMessageRes(MessageType messageType, Long memberId, String message, int unreadCnt, LocalDateTime createdAt) {
+    private ChatMessageRes(MessageType messageType, Long memberId, String message, LocalDateTime createdAt, int unreadCnt) {
         super(messageType);
         this.memberId = memberId;
         this.message = message;
@@ -21,13 +21,13 @@ public class ChatMessageRes extends MessageRes {
         this.createdAt = createdAt;
     }
 
-    public static ChatMessageRes createRes(MessageType messageType, ChatMessage chatMessage) {
+    public static ChatMessageRes createRes(MessageType messageType, ChatMessage chatMessage, int unreadCnt) {
         return new ChatMessageRes(
                 messageType,
                 chatMessage.getMemberId(),
                 chatMessage.getMessage(),
-                chatMessage.getUnreadCnt(),
-                chatMessage.getCreatedAt()
+                chatMessage.getCreatedAt(),
+                unreadCnt
         );
     }
 }

--- a/src/main/java/com/hwarrk/common/dto/res/ChatRoomRes.java
+++ b/src/main/java/com/hwarrk/common/dto/res/ChatRoomRes.java
@@ -10,15 +10,15 @@ import java.util.Optional;
 public record ChatRoomRes(
     Long chatRoomId,
     String nickname,
-    int unreadCnt,
+    int unreadMessageCnt,
     String lastMessage,
     LocalDateTime createdAt
 ) {
-    public static ChatRoomRes createRes(Long chatRoomId, String nickname, int unreadCnt, Optional<ChatMessage> latestMessage) {
+    public static ChatRoomRes createRes(Long chatRoomId, String nickname, int unreadMessageCnt, Optional<ChatMessage> latestMessage) {
         return ChatRoomRes.builder()
                 .chatRoomId(chatRoomId)
                 .nickname(nickname)
-                .unreadCnt(unreadCnt)
+                .unreadMessageCnt(unreadMessageCnt)
                 .lastMessage(latestMessage.map(ChatMessage::getMessage).orElse(null))
                 .createdAt(latestMessage.map(ChatMessage::getCreatedAt).orElse(null))
                 .build();

--- a/src/main/java/com/hwarrk/common/dto/res/ChatSyncRequestRes.java
+++ b/src/main/java/com/hwarrk/common/dto/res/ChatSyncRequestRes.java
@@ -6,11 +6,13 @@ import lombok.Getter;
 @Getter
 public class ChatSyncRequestRes extends MessageRes {
 
-    private ChatSyncRequestRes(MessageType messageType) {
+    static private final MessageType messageType = MessageType.CHAT_SYNC_REQUEST;
+
+    private ChatSyncRequestRes() {
         super(messageType);
     }
 
-    public static ChatSyncRequestRes createRes(MessageType messageType) {
-        return new ChatSyncRequestRes(messageType);
+    public static MessageRes createRes() {
+        return new ChatSyncRequestRes();
     }
 }

--- a/src/main/java/com/hwarrk/common/dto/res/ChatSyncRequestRes.java
+++ b/src/main/java/com/hwarrk/common/dto/res/ChatSyncRequestRes.java
@@ -4,7 +4,7 @@ import com.hwarrk.common.constant.MessageType;
 import lombok.Getter;
 
 @Getter
-class ChatSyncRequestRes extends MessageRes {
+public class ChatSyncRequestRes extends MessageRes {
 
     private ChatSyncRequestRes(MessageType messageType) {
         super(messageType);

--- a/src/main/java/com/hwarrk/common/dto/res/MessageRes.java
+++ b/src/main/java/com/hwarrk/common/dto/res/MessageRes.java
@@ -16,7 +16,7 @@ public abstract class MessageRes {
         return ChatSyncRequestRes.createRes(messageType);
     }
 
-    public static MessageRes createRes(MessageType messageType, ChatMessage chatMessage) {
-        return ChatMessageRes.createRes(messageType, chatMessage);
+    public static MessageRes createRes(MessageType messageType, ChatMessage chatMessage, int unreadCnt) {
+        return ChatMessageRes.createRes(messageType, chatMessage, unreadCnt);
     }
 }

--- a/src/main/java/com/hwarrk/common/dto/res/MessageRes.java
+++ b/src/main/java/com/hwarrk/common/dto/res/MessageRes.java
@@ -1,7 +1,6 @@
 package com.hwarrk.common.dto.res;
 
 import com.hwarrk.common.constant.MessageType;
-import com.hwarrk.entity.ChatMessage;
 import lombok.Getter;
 
 @Getter
@@ -10,13 +9,5 @@ public abstract class MessageRes {
 
     protected MessageRes(MessageType messageType) {
         this.messageType = messageType;
-    }
-
-    public static MessageRes createRes(MessageType messageType) {
-        return ChatSyncRequestRes.createRes(messageType);
-    }
-
-    public static MessageRes createRes(MessageType messageType, ChatMessage chatMessage, int unreadCnt) {
-        return ChatMessageRes.createRes(messageType, chatMessage, unreadCnt);
     }
 }

--- a/src/main/java/com/hwarrk/common/util/StompHeaderAccessorUtil.java
+++ b/src/main/java/com/hwarrk/common/util/StompHeaderAccessorUtil.java
@@ -17,11 +17,11 @@ public class StompHeaderAccessorUtil {
     private String refreshHeader;
 
     static final String CHAT_ROOM_ID = "chat-room-id";
-    static final String MEMBER_ID = "memberId";
+    static final String MEMBER_ID = "member-id";
     private static final String BEARER = "Bearer ";
 
     public void setMemberIdInSession(StompHeaderAccessor accessor, Long memberId) {
-        accessor.getSessionAttributes().put("memberId", memberId);
+        accessor.getSessionAttributes().put(MEMBER_ID, memberId);
     }
 
     public Long getMemberIdInSession(StompHeaderAccessor accessor) {
@@ -37,7 +37,21 @@ public class StompHeaderAccessorUtil {
     public Long getChatRoomIdInHeader(StompHeaderAccessor accessor) {
         return Optional.ofNullable(accessor.getFirstNativeHeader(CHAT_ROOM_ID))
                 .map(Long::valueOf)
-                .orElseThrow(() -> new GeneralHandler(ErrorStatus.MISSING_CHAT_ROOM_ID));
+                .orElseThrow(() -> new GeneralHandler(ErrorStatus.MISSING_CHAT_ROOM_ID_IN_HEADER));
+    }
+
+    public void setChatRoomIdInSession(StompHeaderAccessor accessor, Long chatRoomId) {
+        accessor.getSessionAttributes().put(CHAT_ROOM_ID, chatRoomId);
+    }
+
+    public Long getChatRoomIdInSession(StompHeaderAccessor accessor) {
+        return Optional.ofNullable((Long) accessor.getSessionAttributes().get(CHAT_ROOM_ID))
+                .orElseThrow(() -> new GeneralHandler(ErrorStatus.MISSING_CHAT_ROOM_ID_IN_SESSION));
+    }
+
+    public Long removeChatRoomIdInSession(StompHeaderAccessor accessor) {
+        return Optional.ofNullable((Long) accessor.getSessionAttributes().remove(CHAT_ROOM_ID))
+                .orElseThrow(() -> new GeneralHandler(ErrorStatus.MISSING_CHAT_ROOM_ID_IN_SESSION));
     }
 
     public String extractToken(StompHeaderAccessor accessor, TokenType tokenType) {

--- a/src/main/java/com/hwarrk/controller/ChatRoomController.java
+++ b/src/main/java/com/hwarrk/controller/ChatRoomController.java
@@ -46,27 +46,4 @@ public class ChatRoomController {
     public CustomApiResponse<List<ChatRoomRes>> getChatRooms(@AuthenticationPrincipal Long loginId) {
         return CustomApiResponse.onSuccess(chatRoomService.getChatRooms(loginId));
     }
-
-    private final MemberRepository memberRepository;
-    private final ChatRoomRepository chatRoomRepository;
-
-    @GetMapping("/init")
-    public ResponseEntity<Map<String, Long>> init() {
-        Member roomMaker = new Member("방장", "s1", OauthProvider.KAKAO);
-        Member guest = new Member("게스트", "s2", OauthProvider.KAKAO);
-        memberRepository.save(roomMaker);
-        memberRepository.save(guest);
-
-        ChatRoom chatRoom = ChatRoom.emptyChatRoom();
-        chatRoom.addChatRoomMember(new ChatRoomMember(chatRoom, roomMaker));
-        chatRoom.addChatRoomMember(new ChatRoomMember(chatRoom, guest));
-        chatRoomRepository.save(chatRoom);
-
-        Map<String, Long> response = new HashMap<>();
-        response.put("chatRoomId", chatRoom.getId());
-        response.put("roomMakerId", roomMaker.getId());
-        response.put("guestId", guest.getId());
-
-        return ResponseEntity.ok(response);
-    }
 }

--- a/src/main/java/com/hwarrk/controller/ChatRoomController.java
+++ b/src/main/java/com/hwarrk/controller/ChatRoomController.java
@@ -1,17 +1,26 @@
 package com.hwarrk.controller;
 
 import com.hwarrk.common.apiPayload.CustomApiResponse;
+import com.hwarrk.common.constant.OauthProvider;
 import com.hwarrk.common.dto.res.ChatRoomCreateRes;
 import com.hwarrk.common.dto.res.ChatRoomRes;
+import com.hwarrk.entity.ChatRoom;
+import com.hwarrk.entity.ChatRoomMember;
+import com.hwarrk.entity.Member;
+import com.hwarrk.repository.ChatRoomRepository;
+import com.hwarrk.repository.MemberRepository;
 import com.hwarrk.service.ChatRoomService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Tag(name = "채팅 방")
 @RestController
@@ -38,4 +47,26 @@ public class ChatRoomController {
         return CustomApiResponse.onSuccess(chatRoomService.getChatRooms(loginId));
     }
 
+    private final MemberRepository memberRepository;
+    private final ChatRoomRepository chatRoomRepository;
+
+    @GetMapping("/init")
+    public ResponseEntity<Map<String, Long>> init() {
+        Member roomMaker = new Member("방장", "s1", OauthProvider.KAKAO);
+        Member guest = new Member("게스트", "s2", OauthProvider.KAKAO);
+        memberRepository.save(roomMaker);
+        memberRepository.save(guest);
+
+        ChatRoom chatRoom = ChatRoom.emptyChatRoom();
+        chatRoom.addChatRoomMember(new ChatRoomMember(chatRoom, roomMaker));
+        chatRoom.addChatRoomMember(new ChatRoomMember(chatRoom, guest));
+        chatRoomRepository.save(chatRoom);
+
+        Map<String, Long> response = new HashMap<>();
+        response.put("chatRoomId", chatRoom.getId());
+        response.put("roomMakerId", roomMaker.getId());
+        response.put("guestId", guest.getId());
+
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/hwarrk/entity/ChatMessage.java
+++ b/src/main/java/com/hwarrk/entity/ChatMessage.java
@@ -26,8 +26,6 @@ public class ChatMessage {
 
     private String message;
 
-    private int unreadCnt;
-
     @CreatedDate
     @Column(updatable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/com/hwarrk/jwt/JwtAuthenticationInterceptor.java
+++ b/src/main/java/com/hwarrk/jwt/JwtAuthenticationInterceptor.java
@@ -1,0 +1,37 @@
+package com.hwarrk.jwt;
+
+import com.hwarrk.common.constant.TokenType;
+import com.hwarrk.common.util.StompHeaderAccessorUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.stereotype.Component;
+
+import static org.springframework.messaging.simp.stomp.StompCommand.CONNECT;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationInterceptor implements ChannelInterceptor {
+
+    private final TokenUtil tokenUtil;
+    private final StompHeaderAccessorUtil stompHeaderAccessorUtil;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+
+        if (accessor.getCommand() == CONNECT) {
+            String token = stompHeaderAccessorUtil.extractToken(accessor, TokenType.ACCESS_TOKEN);
+            
+            Long memberId = tokenUtil.validateTokenAndGetMemberId(token);
+            stompHeaderAccessorUtil.setMemberIdInSession(accessor, memberId);
+
+            Long chatRoomId = stompHeaderAccessorUtil.getChatRoomIdInHeader(accessor);
+            stompHeaderAccessorUtil.setChatRoomIdInSession(accessor, chatRoomId);
+        }
+
+        return message;
+    }
+}

--- a/src/main/java/com/hwarrk/jwt/JwtAuthenticationInterceptor.java
+++ b/src/main/java/com/hwarrk/jwt/JwtAuthenticationInterceptor.java
@@ -24,7 +24,7 @@ public class JwtAuthenticationInterceptor implements ChannelInterceptor {
 
         if (accessor.getCommand() == CONNECT) {
             String token = stompHeaderAccessorUtil.extractToken(accessor, TokenType.ACCESS_TOKEN);
-            
+
             Long memberId = tokenUtil.validateTokenAndGetMemberId(token);
             stompHeaderAccessorUtil.setMemberIdInSession(accessor, memberId);
 

--- a/src/main/java/com/hwarrk/redis/RedisChatUtil.java
+++ b/src/main/java/com/hwarrk/redis/RedisChatUtil.java
@@ -2,44 +2,35 @@ package com.hwarrk.redis;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.SetOperations;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Component;
+
+import java.util.Set;
 
 @Component
 @RequiredArgsConstructor
 public class RedisChatUtil {
-    private final RedisTemplate<Long, Long> memberChatRoomMap;
-    private final RedisTemplate<String, Integer> activeCntInChatRoom;
 
-    static final String prefix = "chat-room-";
+    private final RedisTemplate<Long, Long> chatRoom2Members;
 
-    public void setMemberInChatRoom(Long memberId, Long chatRoomId) {
-        ValueOperations<Long, Long> valueOperations = memberChatRoomMap.opsForValue();
-        valueOperations.set(memberId, chatRoomId);
+    public void addChatRoom2Member(Long chatRoomId, Long memberId) {
+        SetOperations<Long, Long> ops = chatRoom2Members.opsForSet();
+        ops.add(chatRoomId, memberId);
     }
 
-    public Long getChatRoomId(Long memberId) {
-        ValueOperations<Long, Long> valueOperations = memberChatRoomMap.opsForValue();
-        return valueOperations.get(memberId);
+    public Set<Long> getOnlineMembers(Long chatRoomId) {
+        SetOperations<Long, Long> ops = chatRoom2Members.opsForSet();
+        return ops.members(chatRoomId);
     }
 
-    public void deleteMemberInChatRoom(Long memberId) {
-        memberChatRoomMap.delete(memberId);
+    public int getOnlineMemberCntInChatRoom(Long chatRoomId) {
+        SetOperations<Long, Long> ops = chatRoom2Members.opsForSet();
+        return ops.members(chatRoomId).size();
     }
 
-    public void incrementActiveCnt(Long key) {
-        ValueOperations<String, Integer> valueOperations = activeCntInChatRoom.opsForValue();
-        valueOperations.increment(prefix + key);
-    }
-
-    public void decrementActiveCnt(Long key) {
-        ValueOperations<String, Integer> valueOperations = activeCntInChatRoom.opsForValue();
-        if (valueOperations.decrement(prefix + key) <= 0)
-            activeCntInChatRoom.delete(prefix + key);
-    }
-
-    public Integer getActiveCntInChatRoom(Long key) {
-        ValueOperations<String, Integer> valueOperations = activeCntInChatRoom.opsForValue();
-        return valueOperations.get(prefix + key);
+    public void removeChatRoom2Member(Long chatRoomId, Long memberId) {
+        SetOperations<Long, Long> ops = chatRoom2Members.opsForSet();
+        ops.remove(chatRoomId, memberId);
     }
 }

--- a/src/main/java/com/hwarrk/repository/ChatMessageRepository.java
+++ b/src/main/java/com/hwarrk/repository/ChatMessageRepository.java
@@ -15,4 +15,6 @@ public interface ChatMessageRepository extends MongoRepository<ChatMessage, Long
     List<ChatMessage> findByChatRoomIdOrderByCreatedAtAsc(Long chatRoomId);
 
     int countByChatRoomIdAndCreatedAtAfter(Long chatRoomId, LocalDateTime lastEntryTime);
+
+    boolean existsByChatRoomIdAndCreatedAtAfter(Long chatRoomId, LocalDateTime lastEntryTime);
 }

--- a/src/main/java/com/hwarrk/service/ChatMessageService.java
+++ b/src/main/java/com/hwarrk/service/ChatMessageService.java
@@ -3,7 +3,6 @@ package com.hwarrk.service;
 import com.hwarrk.common.EntityFacade;
 import com.hwarrk.common.apiPayload.code.statusEnums.ErrorStatus;
 import com.hwarrk.common.constant.MessageType;
-import com.hwarrk.common.constant.TokenType;
 import com.hwarrk.common.dto.req.ChatMessageReq;
 import com.hwarrk.common.dto.res.MessageRes;
 import com.hwarrk.common.exception.GeneralHandler;
@@ -12,7 +11,6 @@ import com.hwarrk.entity.ChatMessage;
 import com.hwarrk.entity.ChatRoom;
 import com.hwarrk.entity.ChatRoomMember;
 import com.hwarrk.entity.Member;
-import com.hwarrk.jwt.TokenUtil;
 import com.hwarrk.redis.RedisChatUtil;
 import com.hwarrk.repository.ChatMessageRepository;
 import com.hwarrk.repository.ChatMessageRepositoryCustom;
@@ -79,7 +77,7 @@ public class ChatMessageService {
 
         chatRoom.getChatRoomMember(member.getId()); // 예외처리 용도
 
-        setMemberActiveInChatRoom(member.getId(), chatRoom.getId());
+        enterChatRoom(member.getId(), chatRoom.getId());
 
         readUnreadMessages(chatRoom, member.getId());
     }
@@ -94,7 +92,7 @@ public class ChatMessageService {
         ChatRoomMember chatRoomMember = chatRoom.getChatRoomMember(member.getId());
         chatRoomMember.updateLastEntryTime();
 
-        removeActiveMemberInChatRoom(member.getId(), chatRoom.getId());
+        exitChatRoom(member.getId(), chatRoom.getId());
     }
 
     private void sendToChatRoom(Long chatRoomId, ChatMessage chatMessage) {
@@ -120,12 +118,12 @@ public class ChatMessageService {
         }
     }
 
-    private void setMemberActiveInChatRoom(Long memberId, Long chatRoomId) {
+    private void enterChatRoom(Long memberId, Long chatRoomId) {
         redisChatUtil.setMemberInChatRoom(memberId, chatRoomId);
         redisChatUtil.incrementActiveCnt(chatRoomId);
     }
 
-    private void removeActiveMemberInChatRoom(Long memberId, Long chatRoomId) {
+    private void exitChatRoom(Long memberId, Long chatRoomId) {
         redisChatUtil.deleteMemberInChatRoom(memberId);
         redisChatUtil.decrementActiveCnt(chatRoomId);
     }

--- a/src/main/java/com/hwarrk/service/ChatMessageService.java
+++ b/src/main/java/com/hwarrk/service/ChatMessageService.java
@@ -4,6 +4,8 @@ import com.hwarrk.common.EntityFacade;
 import com.hwarrk.common.apiPayload.code.statusEnums.ErrorStatus;
 import com.hwarrk.common.constant.MessageType;
 import com.hwarrk.common.dto.req.ChatMessageReq;
+import com.hwarrk.common.dto.res.ChatMessageRes;
+import com.hwarrk.common.dto.res.ChatSyncRequestRes;
 import com.hwarrk.common.dto.res.MessageRes;
 import com.hwarrk.common.exception.GeneralHandler;
 import com.hwarrk.common.util.StompHeaderAccessorUtil;
@@ -62,7 +64,7 @@ public class ChatMessageService {
     }
 
     private void sendMessage(Long chatRoomId, ChatMessage chatMessage, int unreadCnt) {
-        MessageRes messageRes = MessageRes.createRes(MessageType.CHAT_MESSAGE, chatMessage, unreadCnt);
+        MessageRes messageRes = ChatMessageRes.createRes(chatMessage, unreadCnt);
         rabbitTemplate.convertAndSend(ROUTING_KEY_PREFIX + chatRoomId, messageRes);
     }
 
@@ -80,7 +82,7 @@ public class ChatMessageService {
         List<MessageRes> messageResList = chatMessages.stream()
                 .map(chatMessage -> {
                     int unreadCnt = chatRoom.getUnreadCnt(onlineMembersInChatRoom, chatMessage.getCreatedAt());
-                    return MessageRes.createRes(MessageType.CHAT_MESSAGE, chatMessage, unreadCnt);
+                    return ChatMessageRes.createRes(chatMessage, unreadCnt);
                 })
                 .toList();
 
@@ -116,7 +118,7 @@ public class ChatMessageService {
     }
 
     private void sendChatSyncRequestMessage(Long chatRoomId) {
-        MessageRes messageRes = MessageRes.createRes(MessageType.CHAT_SYNC_REQUEST);
+        MessageRes messageRes = ChatSyncRequestRes.createRes();
         rabbitTemplate.convertAndSend(ROUTING_KEY_PREFIX + chatRoomId, messageRes);
     }
 

--- a/src/main/java/com/hwarrk/service/ChatRoomService.java
+++ b/src/main/java/com/hwarrk/service/ChatRoomService.java
@@ -47,16 +47,15 @@ public class ChatRoomService {
                 .map(chatRoom -> {
                     ChatRoomMember otherMember = chatRoom.getOtherMember(member.getId());
 
-                    int unreadCnt = chatMessageRepository.countByChatRoomIdAndCreatedAtAfter(chatRoom.getId(), otherMember.getLastEntryTime());
+                    int unreadMessageCnt = chatMessageRepository.countByChatRoomIdAndCreatedAtAfter(chatRoom.getId(), otherMember.getLastEntryTime());
                     Optional<ChatMessage> lastMessage = chatMessageRepository.findTopByChatRoomIdOrderByCreatedAtDesc(chatRoom.getId());
 
-                    return ChatRoomRes.createRes(chatRoom.getId(), otherMember.getMember().getNickname(), unreadCnt, lastMessage);
+                    return ChatRoomRes.createRes(chatRoom.getId(), otherMember.getMember().getNickname(), unreadMessageCnt, lastMessage);
                 })
                 .toList();
 
         return chatRoomResList;
     }
-
 
 
 }


### PR DESCRIPTION
## ⭐ Summary

> 채팅관련 로직 리팩토링

<br>

## 📌 Tasks

1. 채팅방 입장/퇴장 로직과 jwt 검증 로직을 분리
    - 채팅방 입장/퇴장은 기존 @EventListener를 사용
    - jwt 검증 로직은 ChannelInterceptor를 구현한 JwtAuthenticationInterceptor를 통해 처리
2. chatRoomId를 세션에 저장하여 사용
    - 기존에 redis를 사용하여 유저가 어떤 채팅방에 접속해있는지 관리했는데
    - 어차피 memberId도 session을 활용하고 굳이 redis를 사용할 필요성을 못 느낌
3. MessageRes.createRes(..)를 MessageRes의 구현체인 하위 클래스인 ChatMessageRes.createRes(), ChatSyncRequestRes.createRes()를 사용하도록 수정
    - ``` java
       // 기존 코드는 MessageRes.createRes(CHAT_MESSAGE)가 허용됨
       public static MessageRes createRes(MessageType messageType) {
           return ChatSyncRequestRes.createRes(messageType);
       }
      ```
    - ``` java
       // ChatSyncRequestRes은 MessageType.CHAT_SYNC_REQUEST를 강제하도록 개선
       public class ChatSyncRequestRes extends MessageRes {
      
          static private final MessageType messageType = MessageType.CHAT_SYNC_REQUEST;
      
          private ChatSyncRequestRes() {
              super(messageType);
          }
      
          public static MessageRes createRes() {
              return new ChatSyncRequestRes();
          }
      }
      ```
4. chatMessage.unreadCnt가 아닌 메시지 조회 시 매번 unreadCnt를 계산 하도록 수정
    - 수정 이유
      - 하나의 메시지마다 읽은 유저의 정보를 담기 때문에, 메시지가 쌓일수록 데이터의 양은 더욱 커지게 되고 이로 인해 메모리 사용량은 증가하고 메시지 처리 속도가 느려질 것이다
      - 사용자가 채팅방에 접속하면 읽지 않은 메시지 M개에 대해 Read-Message 테이블로 unreadCnt 수정 쿼리를 요청할 것이다
      - 비록 1:1 채팅방이라 수정 쿼리에 대해 부담이 적겠지만 추후 단체톡방에서도 수정 없이 그대로 사용할 수 있고 1:1 톡방에서도 충분히 더 효율적이라고 판단
    - 구현 방법
      - 채팅방 조회 시 읽지 않은 메시지의 개수
        - 나의 마지막 접속시간 이후에 생성된 메시지를 카운팅
      - 채팅 메시지 조회 시 참가자들이 읽지 않은 횟수 (unreadCnt)
        - 채팅방 전체 참가자 - 현재 채팅방에 접속 중인 인원 - 각 메시지 생성 시간보다 이후에 접속한 참가자의 수
        - 이때 '현재 채팅방에 접속 중인 인원'은 '각 메시지 생성 시간보다 이후에 접속한 참가자의 수'에 계산되지 않도록 구현

<br>

